### PR TITLE
Improve variables naming section

### DIFF
--- a/notes/composite-types.md
+++ b/notes/composite-types.md
@@ -148,29 +148,29 @@ Go provides several ways to initialize a map, but the recommendation is to use `
 maps, since shows clearer the intended value and could prevent accidental errors produced by writing on a nil map.
 
 ```go
-var myMap map[string]int      // Bad, map is will panic on writes
-var myMap = map[string]int{}  // Bad, map is empty and safe to read and write, but is not the clearest option
-mymap := make(map[string]int) // Good
+var employees map[employee]int      // Bad, map is will panic on writes
+var employees = map[employee]int{}  // Bad, map is empty and safe to read and write, but is not the clearest option
+employees := make(map[employee]int) // Good
 ```
 
 In fact, the best practise is to provide an initial capacity, where possible, since provides a better performance by not
 having to dynamically grow the map as elements are added.
 
 ```go
-mymap := make(map[string]int, 10) // Good
+employees := make(map[employee]int, 10) // Good
 ```
 
 There is a case in which ```make(..)``` function is not required, and that is when th map holds a fixed list of
 elements. In that case, the preferred way is to use map literals to initialize the map.
 
 ```go
-myMap := make(map[string]int, 2) // Bad
-myMap[0] = "Hello"
-myMap[1] = "World"
+employees := make(map[employee]int, 2) // Bad
+employees[0] = NewEmployee("Bob")
+employees[1] = NewEmployee("Alice")
 
-myMap := map[string]int{         // Good
-	0: "Hello",
-	1: "World",
+employees := map[string]int{         // Good
+	0: NewEmployee("Bob"),
+	1: NewEmployee("Alice"),
 }
 ```
 

--- a/notes/program-structure.md
+++ b/notes/program-structure.md
@@ -69,6 +69,14 @@ func ReadDir(dirname string) ([]fs.FileInfo, error) {
 
 ```
 
+Regardless of size, variable type should be excluded from the name. After all, Go is strongly typed, so it is
+unnecessary to track the underlying type on the name.
+
+```go
+usersMap := make(map[User]int) // Bad
+users := make(map[User]int)    // Good
+```
+
 Finally, avoid using Go's [predeclared identifiers](https://go.dev/ref/spec#Predeclared_identifiers), such as types(
 bool, byte, int...) or functions (copy, delete, len, make...) as variable names, since will shadow the original meaning
 and introduce hard to find bugs, especially in those cases where the compiler is not able to detect it.


### PR DESCRIPTION
Add an explanation about how the variable names should not include the underlying type